### PR TITLE
마스킹 처리

### DIFF
--- a/mask/hybrid_mask.py
+++ b/mask/hybrid_mask.py
@@ -1,0 +1,56 @@
+from lime.lime_text import LimeTextExplainer
+import numpy as np
+import torch
+from encoder.jamo_encoder import text_to_tensor
+
+# class_names: 0 = 비욕설, 1 = 욕설
+class_names = ['clean', 'abusive']
+
+def custom_tokenizer(text):
+    return text.split()  # 공백 기준만 사용해서 특수문자 포함 단어를 유지
+
+# LIME용 예측 함수: 리스트[str] → 확률 반환
+def lime_predict(texts, model, device):
+    results = []
+    for t in texts:
+        x = text_to_tensor(t, max_len=600)
+        x_tensor = torch.tensor(x, dtype=torch.float32).unsqueeze(0).to(device)
+        with torch.no_grad():
+            pred = model(x_tensor).item()
+        results.append([1 - pred, pred])
+    return np.array(results)
+
+
+# 단어 단위로 욕설 여부 판별 함수
+def is_offensive_word(word, model, device, threshold=0.2):
+    x = text_to_tensor(word, max_len=600)
+    x_tensor = torch.tensor(x, dtype=torch.float32).unsqueeze(0).to(device)
+    with torch.no_grad():
+        prob = model(x_tensor).item()
+    return prob > threshold
+
+
+def hybrid_mask_text(text, model, device, threshold=0.2, lime_weight=0.05):
+    # 어절 단위 분리
+    words = text.split()
+
+    # 전체 문장에 대해 LIME 실행
+    explainer = LimeTextExplainer(class_names=["clean", "abusive"])
+
+    explanation = explainer.explain_instance(
+        text_instance=text,
+        classifier_fn=lambda texts: lime_predict(texts, model, device),
+        num_features=10,
+        labels=[1]
+    )
+
+    # LIME이 기여도가 높다고 판단한 단어 목록
+    lime_tokens = [w for w, weight in explanation.as_list(label=1) if weight > lime_weight]
+
+    # 최종 마스킹: 어절 예측 or LIME 기여 둘 중 하나라도 해당되면 마스킹
+    masked_words = [
+        "***" if is_offensive_word(w, model, device, threshold=threshold) or w in lime_tokens else w
+        for w in words
+    ]
+    return " ".join(masked_words)
+

--- a/mask/lime_mask.py
+++ b/mask/lime_mask.py
@@ -1,0 +1,52 @@
+from lime.lime_text import LimeTextExplainer
+import numpy as np
+import torch
+from encoder.jamo_encoder import text_to_tensor
+
+def lime_predict(texts, model, device):
+    model.eval()
+    outputs = []
+    for text in texts:
+        x = text_to_tensor(text, max_len=600)
+        x_tensor = torch.tensor(np.array([x]), dtype=torch.float32).to(device)
+        with torch.no_grad():
+            logit = model(x_tensor)
+            prob = torch.sigmoid(logit).item()
+        outputs.append([1 - prob, prob])  # [clean, abusive]
+    return np.array(outputs)
+
+
+def lime_mask(text, model, device, threshold=0.2, top_k=10):
+    model.eval()
+
+    # 1. 전체 문장 욕설 예측
+    x = text_to_tensor(text, max_len=600)
+    x_tensor = torch.tensor(np.expand_dims(x, axis=0), dtype=torch.float32).to(device)
+    with torch.no_grad():
+        logit = model(x_tensor)
+        pred_prob = torch.sigmoid(logit).item()
+
+    if pred_prob < 0.4:
+        return text  # 욕설 가능성 낮으면 원문 그대로 반환
+
+    # 2. LIME 해석기 생성
+    explainer = LimeTextExplainer(class_names=["clean", "abusive"])
+    explanation = explainer.explain_instance(
+        text_instance=text,
+        classifier_fn=lambda x: lime_predict(x, model, device),
+        num_features=top_k,
+        labels=[1]
+    )
+
+    # 3. 중요 단어 추출
+    important_words = [
+        word for word, weight in explanation.as_list(label=1)
+        if weight >= threshold
+    ]
+
+    # 4. 마스킹 처리
+    masked = text
+    for word in important_words:
+        masked = masked.replace(word, "***")
+
+    return masked

--- a/mask/word_mask.py
+++ b/mask/word_mask.py
@@ -1,0 +1,44 @@
+# 단어 단위로 욕설 여부 판별 함수
+from sympy.printing.pytorch import torch
+from encoder.jamo_encoder import text_to_tensor
+
+def is_offensive_word(word, model, device, threshold=0.7):
+    x = text_to_tensor(word, max_len=600)
+    x_tensor = torch.tensor(x, dtype=torch.float32).unsqueeze(0).to(device)
+    with torch.no_grad():
+        # model_v3 사용 시
+        logit = model(x_tensor)
+        prob = torch.sigmoid(logit).item()
+        # prob = model(x_tensor).item()
+    return prob > threshold
+
+def word_mask(text, model, device):
+    words = text.split()
+    masked_words = ["***" if is_offensive_word(w, model, device) else w for w in words]
+    masked = " ".join(masked_words)
+    return masked
+
+def word_mask_window2(text, model, device):
+    words = text.split()
+    masked_flags = [False] * len(words)  # 각 단어가 마스킹될지 여부
+    masked_words = words.copy()
+    if len(words) == 1:
+        if is_offensive_word(words[0], model, device):
+            return "***"
+        else:
+            return words[0]
+
+    for i in range(len(words) - 1):
+        combined = words[i] + words[i+1]
+        if is_offensive_word(combined, model, device):
+            if is_offensive_word(words[i], model, device):
+                masked_flags[i] = True
+                masked_words[i] = "***"
+            else:
+                masked_flags[i+1] = True
+                masked_words[i+1] = "***"
+    if is_offensive_word(words[-1], model, device):
+        masked_flags[-1] = True
+        masked_words[-1] = "***"
+
+    return " ".join(masked_words)

--- a/profanity_cnn.py
+++ b/profanity_cnn.py
@@ -1,0 +1,43 @@
+import torch
+from encoder.jamo_encoder import VECTOR_SIZE
+from torch import nn
+
+# model_v3
+class ProfanityCNN(nn.Module):
+    def __init__(self, input_dim=VECTOR_SIZE, seq_len=600):
+        super().__init__()
+        self.conv1 = nn.Conv1d(input_dim, 128, kernel_size=6)
+        self.pool1 = nn.MaxPool1d(kernel_size=3)
+        self.conv2 = nn.Conv1d(128, 128, kernel_size=9)
+        self.pool2 = nn.MaxPool1d(kernel_size=3)
+        self.conv3 = nn.Conv1d(128, 128, kernel_size=12)
+        self.pool3 = nn.MaxPool1d(kernel_size=3)
+
+        with torch.no_grad():
+            dummy_input = torch.zeros(1, input_dim, seq_len)
+            x = self.pool1(torch.relu(self.conv1(dummy_input)))
+            x = self.pool2(torch.relu(self.conv2(x)))
+            x = self.pool3(torch.relu(self.conv3(x)))
+            self.flatten_size = x.view(1, -1).shape[1]
+
+        self.fc1 = nn.Linear(self.flatten_size, 128)
+        self.dropout1 = nn.Dropout(0.5)
+        self.fc2 = nn.Linear(128, 64)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc3 = nn.Linear(64, 1)
+
+    def forward(self, x):
+        x = x.permute(0, 2, 1)
+        x = self.pool1(torch.relu(self.conv1(x)))
+        x = self.pool2(torch.relu(self.conv2(x)))
+        x = self.pool3(torch.relu(self.conv3(x)))
+        x = x.view(x.size(0), -1)
+        x = self.dropout1(torch.relu(self.fc1(x)))
+        x = self.dropout2(torch.relu(self.fc2(x)))
+        return self.fc3(x).squeeze()
+
+# 모델 불러오기
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+model = ProfanityCNN(input_dim=VECTOR_SIZE).to(device)
+model.load_state_dict(torch.load("model/clean_bot_model_v3.pt", map_location=device))
+model.eval()


### PR DESCRIPTION
## 어절 단위 마스킹 처리
- 띄어쓰기 기준으로 단어를 분리하여 model에 적용

## 어절 단위 window size 2 마스킹 처리
- 기존 어절 단위 마스킹의 문제점
  - "ㅂ ㅅ" 와 같이 욕설이지만 공백을 기준으로 처리하여 "ㅂ", "ㅅ" 따로 model이 분석
  - 이로 인해 욕설임에도 욕설이 아닌 것으로 판단하는 문제
- 문제 해결 전략
  - 두 단어씩 묶어서 욕설인지 판단
  - 묶은 단어가 욕설로 판단되면 앞 단어와 뒷 단어의 욕설 유무 확인 후 마스킹

## LIME 알고리즘을 활용한 마스킹 처리
- LIME 알고리즘을 사용하여 문장이 욕설인 경우 최대 10개 단어의 욕설 기여도를 평가
- 설정한 threshold를 넘어가면 단어를 욕설로 판단
- 실시간 채팅에서 사용하기에 느림

## Hybrid 마스킹 처리
- 어절단위 마스킹과 LIME 단위의 마스킹 처리를 동시에 진행
- 각각의 마스킹이 처리하지 못하는 부분까지 처리해줌
- 넷 중 가장 정확한 마스킹 처리 가능
- 이 방법도 실시간 채팅에서 사용하기에 느림